### PR TITLE
Backport some helpers from OZ 5.0.1 to we can support OZ 4.8.1

### DIFF
--- a/src/AddressHelper.sol
+++ b/src/AddressHelper.sol
@@ -24,6 +24,14 @@ import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 library AddressHelper {
     using Strings for *;
 
+    bytes16 private constant HEX_DIGITS = "0123456789abcdef";
+    uint8 private constant ADDRESS_LENGTH = 20;
+
+    /**
+     * @dev The `value` string doesn't fit in the specified `length`.
+     */
+    error StringsInsufficientHexLength(uint256 value, uint256 length);
+
     function toEtherscanLink(address _address) internal pure returns (string memory) {
         return string(abi.encodePacked("https://etherscan.io/address/", _address.toHexString()));
     }
@@ -37,6 +45,56 @@ library AddressHelper {
     }
 
     function toString(address _address) internal pure returns (string memory) {
-        return (_address).toChecksumHexString();
+        return toChecksumHexString(_address);
+    }
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.
+     */
+    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {
+        uint256 localValue = value;
+        bytes memory buffer = new bytes(2 * length + 2);
+        buffer[0] = "0";
+        buffer[1] = "x";
+        for (uint256 i = 2 * length + 1; i > 1; --i) {
+            buffer[i] = HEX_DIGITS[localValue & 0xf];
+            localValue >>= 4;
+        }
+        if (localValue != 0) {
+            revert StringsInsufficientHexLength(value, length);
+        }
+        return string(buffer);
+    }
+
+    /**
+     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal
+     * representation.
+     */
+    function toHexString(address addr) internal pure returns (string memory) {
+        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);
+    }
+
+    /**
+     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal
+     * representation, according to EIP-55.
+     */
+    function toChecksumHexString(address addr) internal pure returns (string memory) {
+        bytes memory buffer = bytes(toHexString(addr));
+
+        // hash the hex part of buffer (skip length + 2 bytes, length 40)
+        uint256 hashValue;
+        assembly ("memory-safe") {
+            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))
+        }
+
+        for (uint256 i = 41; i > 1; --i) {
+            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)
+            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {
+                // case shift by xoring with 0x20
+                buffer[i] ^= 0x20;
+            }
+            hashValue >>= 4;
+        }
+        return string(buffer);
     }
 }

--- a/src/Logger.sol
+++ b/src/Logger.sol
@@ -89,7 +89,16 @@ library Logger {
 
     function addressWithEtherscanLink(string memory _string, address _address) public pure {
         console.log(
-            string(abi.encodePacked(_string, " ", _address.toHexString(), " (", _address.toEtherscanLink(), ")"))
+            string(
+                abi.encodePacked(
+                    _string,
+                    " ",
+                    AddressHelper.toHexString(_address),
+                    " (",
+                    _address.toEtherscanLink(),
+                    ")"
+                )
+            )
         );
     }
 

--- a/src/StringsHelper.sol
+++ b/src/StringsHelper.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.8.0;
 
 import { console2 as console } from "forge-std/Test.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 
 library StringsHelper {
     using Strings for *;
@@ -78,6 +79,13 @@ library StringsHelper {
         if (_number < 0) {
             return string.concat("-", Strings.toString(uint256(-_number)));
         }
-        return Strings.toStringSigned(_number);
+        return toStringSigned(_number);
+    }
+
+    /**
+     * @dev Converts a `int256` to its ASCII `string` decimal representation.
+     */
+    function toStringSigned(int256 value) internal pure returns (string memory) {
+        return string.concat(value < 0 ? "-" : "", toString(SignedMath.abs(value)));
     }
 }


### PR DESCRIPTION
Unfortunately, [Wormhole NttManager](https://github.com/wormhole-foundation/native-token-transfers) uses OZ 4.8.1. It's missing some stuff we depend on here. I backported a few helper functions from OZ 5.0.1, to make this library compatible with both versions.